### PR TITLE
remove duplicate 'True' reserved word

### DIFF
--- a/compiler/src/cobalt/parsers/BaseParser.hs
+++ b/compiler/src/cobalt/parsers/BaseParser.hs
@@ -65,7 +65,6 @@ rws = [
   "private",
   "this",
   "mutable",
-  "True",
   "new",
   "package",
   "println",


### PR DESCRIPTION
If we do need it for some reason, we should probably have a comment explaining why.