### PR TITLE
Cobalt 434

### DIFF
--- a/compiler/src/cobalt/AST/AST.hs
+++ b/compiler/src/cobalt/AST/AST.hs
@@ -108,7 +108,7 @@ data Expr
 data Stmt
     = For Stmt AExpr AExpr Expr
     | While BExpr Expr
-    | If Conditional (Maybe Conditional) (Maybe Conditional)
+    | If Conditional (Maybe Conditional)
     | TryBlock ExceptionHandler (Maybe ExceptionHandler) (Maybe ExceptionHandler)
     | Assign Name (Maybe Type) Expr
     | AssignMultiple [Name] (Maybe Type) Expr
@@ -127,7 +127,6 @@ data Stmt
 
 data Conditional
     = IfStatement BExpr Expr
-    | ElifStatement BExpr Expr
     | ElseStatement Expr
     deriving (Show, Eq)
 

--- a/compiler/src/cobalt/AST/AST.hs
+++ b/compiler/src/cobalt/AST/AST.hs
@@ -126,7 +126,9 @@ data Stmt
     deriving (Show, Eq)
 
 data Conditional
-    = IfStatement BExpr Expr
+    = IfExpression BExpr Stmt
+    | ElseExpression Stmt
+    | IfStatement BExpr Expr
     | ElseStatement Expr
     deriving (Show, Eq)
 

--- a/compiler/src/cobalt/Parser/ExprParser.hs
+++ b/compiler/src/cobalt/Parser/ExprParser.hs
@@ -171,14 +171,14 @@ ifStatementParser  = do
     ifInline = do
         try $ do
             rword "if"
-            condition  <- parens bExpr
+            condition  <- choice [try $ parens bExpr, bExpr]
             rword "then"
             expression <- inlineExpressionParser
             return $ IfStatement condition expression
     elifInline = do
         try $ do
             rword "elif"
-            condition  <- parens bExpr
+            condition  <- choice [try $ parens bExpr, bExpr]
             rword "then"
             expression <- inlineExpressionParser
             return $ ElifStatement condition expression
@@ -192,14 +192,14 @@ ifStatementParser  = do
       where
         p = do
             rword "if"
-            condition  <- parens bExpr
+            condition  <- choice [try $ parens bExpr, bExpr]
             rword "then"
             return (L.IndentSome Nothing (return . (IfStatement condition) . Block) statementParser)
     elifDoBlock = try $ L.indentBlock scn p
       where
         p = do
             rword "elif"
-            condition  <- parens bExpr
+            condition  <- choice [try $ parens bExpr, bExpr]
             rword "then"
             return (L.IndentSome Nothing (return . (ElifStatement condition) . Block) statementParser)
     elseDoBlock = try $ L.indentBlock scn p

--- a/compiler/test/tests/cobalt/Parser/BExprParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/BExprParserTest.hs
@@ -32,4 +32,14 @@ testBExprParserFail = do
         (Identifier "true")
         (case (parse (bExpr) "" code) of
              Left  _ -> BError
-             Right x -> x)-}
+             Right x -> x)
+
+testBExprParenthesesConsumerParser :: Test
+testBExprParenthesesConsumerParser = do
+    let code = "(((True)))"
+    TestCase $ assertEqual code
+        (BoolConst True)
+        (case (parse (bExpr) "" code) of
+             Left  _ -> BError
+             Right x -> x)
+-}

--- a/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
@@ -12,7 +12,7 @@ testIfStmtParser = do
                            , "    x"
                            ]
     let testTrue = TestCase $ assertEqual codeTrue
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing Nothing)
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing)
                        (case (parse (ifStatementParser) "" codeTrue) of
                            Left  e -> error (show e)
                            Right x -> x)
@@ -21,7 +21,7 @@ testIfStmtParser = do
                             , "    x"
                             ]
     let testFalse = TestCase $ assertEqual codeFalse
-                        (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing Nothing)
+                        (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
                         (case (parse (ifStatementParser) "" codeFalse) of
                            Left  e -> error (show e)
                            Right x -> x)
@@ -33,7 +33,7 @@ testIfStmtParser = do
                                , "  j"
                                ]
     let testElifTrue = TestCase $ assertEqual codeElifTrue
-                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) Nothing)
+                           (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
                            (case (parse (ifStatementParser) "" codeElifTrue) of
                                Left  e -> error (show e)
                                Right x -> x)
@@ -44,7 +44,7 @@ testIfStmtParser = do
                                 , "  j"
                                 ]
     let testElifFalse = TestCase $ assertEqual codeElifFalse
-                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "j")]))) Nothing)
+                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
                             (case (parse (ifStatementParser) "" codeElifFalse) of
                                 Left  e -> error (show e)
                                 Right x -> x)
@@ -57,7 +57,7 @@ testIfStmtParser = do
                                , "  k"
                                ]
     let testElifElse = TestCase $ assertEqual codeElifElse
-                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) (Just (ElseStatement (Block [Identifier (Name "k")]))))
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElseStatement (Block [Identifier (Name "k")]))))
                            (case (parse (ifStatementParser) "" codeElifElse) of
                                Left  e -> error (show e)
                                Right x -> x)
@@ -68,7 +68,7 @@ testIfStmtParser = do
                            , "  k"
                            ]
     let testElse = TestCase $ assertEqual codeElse
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) Nothing (Just (ElseStatement (Block [Identifier (Name "k")]))))
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElseStatement (Block [Identifier (Name "k")]))))
                        (case (parse (ifStatementParser) "" codeElse) of
                            Left  e -> error (show e)
                            Right x -> x)
@@ -79,21 +79,21 @@ testIfStmtParserInline :: Test
 testIfStmtParserInline = do
     let codeTrue = "if(True) then x"
     let testTrue = TestCase $ assertEqual codeTrue
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing Nothing)
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing)
                        (case (parse (ifStatementParser) "" codeTrue) of
                            Left  e -> error (show e)
                            Right x -> x)
 
     let codeFalse = "if(False) then x"
     let testFalse = TestCase $ assertEqual codeFalse
-                        (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing Nothing)
+                        (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
                         (case (parse (ifStatementParser) "" codeFalse) of
                            Left  e -> error (show e)
                            Right x -> x)
 
     let codeSingleLine = "if(True) then x elif False then y else z"
     let testSingleLine = TestCase $ assertEqual codeSingleLine
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "y")]))) (Just (ElseStatement (Block [Identifier (Name "z")]))))
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) (Just (ElseStatement (Block [Identifier (Name "z")]))))
                        (case (parse (ifStatementParser) "" codeSingleLine) of
                            Left  e -> error (show e)
                            Right x -> x)
@@ -102,7 +102,7 @@ testIfStmtParserInline = do
                                , "elif(True) then j"
                                ]
     let testElifTrue = TestCase $ assertEqual codeElifTrue
-                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) Nothing)
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) Nothing)
                            (case (parse (ifStatementParser) "" codeElifTrue) of
                                Left  e -> error (show e)
                                Right x -> x)
@@ -111,7 +111,7 @@ testIfStmtParserInline = do
                                 , "elif(False) then j"
                                 ]
     let testElifFalse = TestCase $ assertEqual codeElifFalse
-                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "j")]))) Nothing)
+                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
                             (case (parse (ifStatementParser) "" codeElifFalse) of
                                 Left  e -> error (show e)
                                 Right x -> x)
@@ -120,7 +120,7 @@ testIfStmtParserInline = do
                                         , "elif False then j"
                                         ]
     let testElifFalseNoParens = TestCase $ assertEqual codeElifFalseNoParens
-                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "j")]))) Nothing)
+                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) Nothing)
                             (case (parse (ifStatementParser) "" codeElifFalseNoParens) of
                                 Left  e -> error (show e)
                                 Right x -> x)
@@ -130,7 +130,7 @@ testIfStmtParserInline = do
                                , "else k"
                                ]
     let testElifElse = TestCase $ assertEqual codeElifElse
-                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) (Just (ElseStatement (Block [Identifier (Name "k")]))))
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElseStatement (Block [Identifier (Name "k")]))))
                            (case (parse (ifStatementParser) "" codeElifElse) of
                                Left  e -> error (show e)
                                Right x -> x)
@@ -139,7 +139,7 @@ testIfStmtParserInline = do
                            , "else k"
                            ]
     let testElse = TestCase $ assertEqual codeElse
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) Nothing (Just (ElseStatement (Block [Identifier (Name "k")]))))
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElseStatement (Block [Identifier (Name "k")]))))
                        (case (parse (ifStatementParser) "" codeElse) of
                            Left  e -> error (show e)
                            Right x -> x)
@@ -149,7 +149,7 @@ testIfStmtParserInline = do
                                      , "else l;m;n"
                                      ]
     let testMultipleInline = TestCase $ assertEqual codeMultipleInline
-                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "x"),Identifier (Name "y"),Identifier (Name "z")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "i"),Identifier (Name "j"),Identifier (Name "k")]))) (Just (ElseStatement (Block [Identifier (Name "l"),Identifier (Name "m"),Identifier (Name "n")]))))
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "x"),Identifier (Name "y"),Identifier (Name "z")])) (Just (ElseStatement (Block [Identifier (Name "l"),Identifier (Name "m"),Identifier (Name "n")]))))
                            (case (parse (ifStatementParser) "" codeMultipleInline) of
                                Left  e -> error (show e)
                                Right x -> x)

--- a/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
@@ -8,7 +8,7 @@ import Parser.ExprParser
 
 testIfStmtParser :: Test
 testIfStmtParser = do
-    let codeTrue = unlines [ "if(True) then do"
+    let codeTrue = unlines [ "if(True) then"
                            , "    x"
                            ]
     let testTrue = TestCase $ assertEqual codeTrue
@@ -17,7 +17,7 @@ testIfStmtParser = do
                            Left  e -> error (show e)
                            Right x -> x)
 
-    let codeFalse = unlines [ "if(False) then do"
+    let codeFalse = unlines [ "if(False) then"
                             , "    x"
                             ]
     let testFalse = TestCase $ assertEqual codeFalse
@@ -27,9 +27,9 @@ testIfStmtParser = do
                            Right x -> x)
 
 
-    let codeElifTrue = unlines [ "if(True) then do"
+    let codeElifTrue = unlines [ "if(True) then"
                                , "  i"
-                               , "elif(True) then do"
+                               , "elif(True) then"
                                , "  j"
                                ]
     let testElifTrue = TestCase $ assertEqual codeElifTrue
@@ -38,9 +38,9 @@ testIfStmtParser = do
                                Left  e -> error (show e)
                                Right x -> x)
 
-    let codeElifFalse = unlines [ "if(False) then do"
+    let codeElifFalse = unlines [ "if(False) then"
                                 , "  i"
-                                , "elif(False) then do"
+                                , "elif(False) then"
                                 , "  j"
                                 ]
     let testElifFalse = TestCase $ assertEqual codeElifFalse
@@ -49,11 +49,11 @@ testIfStmtParser = do
                                 Left  e -> error (show e)
                                 Right x -> x)
 
-    let codeElifElse = unlines [ "if(True) then do"
+    let codeElifElse = unlines [ "if(True) then"
                                , "  i"
-                               , "elif(True) then do"
+                               , "elif(True) then"
                                , "  j"
-                               , "else do"
+                               , "else"
                                , "  k"
                                ]
     let testElifElse = TestCase $ assertEqual codeElifElse
@@ -62,9 +62,9 @@ testIfStmtParser = do
                                Left  e -> error (show e)
                                Right x -> x)
 
-    let codeElse = unlines [ "if(True) then do"
+    let codeElse = unlines [ "if(True) then"
                            , "  i"
-                           , "else do"
+                           , "else"
                            , "  k"
                            ]
     let testElse = TestCase $ assertEqual codeElse
@@ -91,6 +91,12 @@ testIfStmtParserInline = do
                            Left  e -> error (show e)
                            Right x -> x)
 
+    let codeSingleLine = "if(True) then x elif False then y else z"
+    let testSingleLine = TestCase $ assertEqual codeSingleLine
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing Nothing)
+                       (case (parse (ifStatementParser) "" codeSingleLine) of
+                           Left  e -> error (show e)
+                           Right x -> x)
 
     let codeElifTrue = unlines [ "if(True) then i"
                                , "elif(True) then j"
@@ -110,6 +116,15 @@ testIfStmtParserInline = do
                                 Left  e -> error (show e)
                                 Right x -> x)
 
+    let codeElifFalseNoParens = unlines [ "if False then i"
+                                        , "elif False then j"
+                                        ]
+    let testElifFalseNoParens = TestCase $ assertEqual codeElifFalse
+                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "j")]))) Nothing)
+                            (case (parse (ifStatementParser) "" codeElifFalse) of
+                                Left  e -> error (show e)
+                                Right x -> x)
+
     let codeElifElse = unlines [ "if(True) then i"
                                , "elif(True) then j"
                                , "else k"
@@ -121,7 +136,7 @@ testIfStmtParserInline = do
                                Right x -> x)
 
     let codeElse = unlines [ "if(True) then i"
-                           , "else then k"
+                           , "else k"
                            ]
     let testElse = TestCase $ assertEqual codeElse
                        (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) Nothing (Just (ElseStatement (Block [Identifier (Name "k")]))))
@@ -129,4 +144,4 @@ testIfStmtParserInline = do
                            Left  e -> error (show e)
                            Right x -> x)
 
-    TestList [testTrue, testFalse, testElifTrue, testElifFalse, testElifElse, testElse]
+    TestList [testTrue, testFalse, testSingleLine, testElifTrue, testElifFalse, testElifFalseNoParens, testElifElse, testElse]

--- a/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
@@ -154,4 +154,26 @@ testIfStmtParserInline = do
                                Left  e -> error (show e)
                                Right x -> x)
 
+    let codeMultipleElifsFinishedWithElse = unlines [ "if(True) then x; y; z"
+                                                    , "elif(True) then i;j;k"
+                                                    , "elif(False) then f;"
+                                                    , "else l;m;n"
+                                                    ]
+
+
+    let testMultipleElifsWithoutElse = unlines [ "if(True) then x; y; z"
+                                               , "elif(True) then i;j;k"
+                                               , "elif(False) then f;"
+                                               ]
+
+
+    let testNestedWithoutElseNoParentheses = unlines [ "if(True) then"
+                                                     , "  if(False) then "
+                                                     , "    k"
+                                                     , "  if True then"
+                                                     , "    j"
+                                                     , "else"
+                                                     , "  m"
+                                                     ]
+
     TestList [testTrue, testFalse, testSingleLine, testElifTrue, testElifFalse, testElifFalseNoParens, testElifElse, testElse, testMultipleInline]

--- a/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
@@ -93,7 +93,7 @@ testIfStmtParserInline = do
 
     let codeSingleLine = "if(True) then x elif False then y else z"
     let testSingleLine = TestCase $ assertEqual codeSingleLine
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing Nothing)
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "y")]))) (Just (ElseStatement (Block [Identifier (Name "z")]))))
                        (case (parse (ifStatementParser) "" codeSingleLine) of
                            Left  e -> error (show e)
                            Right x -> x)
@@ -119,9 +119,9 @@ testIfStmtParserInline = do
     let codeElifFalseNoParens = unlines [ "if False then i"
                                         , "elif False then j"
                                         ]
-    let testElifFalseNoParens = TestCase $ assertEqual codeElifFalse
+    let testElifFalseNoParens = TestCase $ assertEqual codeElifFalseNoParens
                             (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "j")]))) Nothing)
-                            (case (parse (ifStatementParser) "" codeElifFalse) of
+                            (case (parse (ifStatementParser) "" codeElifFalseNoParens) of
                                 Left  e -> error (show e)
                                 Right x -> x)
 
@@ -144,4 +144,14 @@ testIfStmtParserInline = do
                            Left  e -> error (show e)
                            Right x -> x)
 
-    TestList [testTrue, testFalse, testSingleLine, testElifTrue, testElifFalse, testElifFalseNoParens, testElifElse, testElse]
+    let codeMultipleInline = unlines [ "if(True) then x; y; z"
+                                     , "elif(True) then i;j;k"
+                                     , "else l;m;n"
+                                     ]
+    let testMultipleInline = TestCase $ assertEqual codeMultipleInline
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "x"),Identifier (Name "y"),Identifier (Name "z")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "i"),Identifier (Name "j"),Identifier (Name "k")]))) (Just (ElseStatement (Block [Identifier (Name "l"),Identifier (Name "m"),Identifier (Name "n")]))))
+                           (case (parse (ifStatementParser) "" codeMultipleInline) of
+                               Left  e -> error (show e)
+                               Right x -> x)
+
+    TestList [testTrue, testFalse, testSingleLine, testElifTrue, testElifFalse, testElifFalseNoParens, testElifElse, testElse, testMultipleInline]

--- a/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
@@ -33,7 +33,7 @@ testIfStmtParser = do
                                , "  j"
                                ]
     let testElifTrue = TestCase $ assertEqual codeElifTrue
-                           (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (IfStatement (BoolConst True) (Block [Identifier (Name "j")]))))
                            (case (parse (ifStatementParser) "" codeElifTrue) of
                                Left  e -> error (show e)
                                Right x -> x)
@@ -44,7 +44,7 @@ testIfStmtParser = do
                                 , "  j"
                                 ]
     let testElifFalse = TestCase $ assertEqual codeElifFalse
-                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
+                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) (Just (IfStatement (BoolConst False) (Block [Identifier (Name "j")]))))
                             (case (parse (ifStatementParser) "" codeElifFalse) of
                                 Left  e -> error (show e)
                                 Right x -> x)

--- a/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
@@ -6,74 +6,127 @@ import Text.Megaparsec
 import AST.AST
 import Parser.ExprParser
 
-testIfStmtParserBooleanTrue :: Test
-testIfStmtParserBooleanTrue = do
-    let code = "if(True)"
-    TestCase $ assertEqual code
-        (If (IfStatement (BoolConst True) (Block [])) Nothing Nothing)
-        (case (parse (ifStatementParser) "" code) of
-             Left  e -> error (show e)
-             Right x -> x)
+testIfStmtParser :: Test
+testIfStmtParser = do
+    let codeTrue = unlines [ "if(True) then do"
+                           , "    x"
+                           ]
+    let testTrue = TestCase $ assertEqual codeTrue
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing Nothing)
+                       (case (parse (ifStatementParser) "" codeTrue) of
+                           Left  e -> error (show e)
+                           Right x -> x)
 
-testIfStmtParserBooleanFalse :: Test
-testIfStmtParserBooleanFalse = do
-    let code = "if(False)"
-    TestCase $ assertEqual code
-        (If (IfStatement (BoolConst False) (Block [])) Nothing Nothing)
-        (case (parse (ifStatementParser) "" code) of
-             Left  e -> error (show e)
-             Right x -> x)
+    let codeFalse = unlines [ "if(False) then do"
+                            , "    x"
+                            ]
+    let testFalse = TestCase $ assertEqual codeFalse
+                        (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing Nothing)
+                        (case (parse (ifStatementParser) "" codeFalse) of
+                           Left  e -> error (show e)
+                           Right x -> x)
 
-testIfStmtParserElifTrue :: Test
-testIfStmtParserElifTrue = do
-    let code = unlines [ "if(True)"
-                       , "  i"
-                       , "elif(True)"
-                       , "  j"
-                       ]
-    TestCase $ assertEqual code
-        (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) Nothing)
-        (case (parse (ifStatementParser) "" code) of
-             Left  e -> error (show e)
-             Right x -> x)
 
-testIfStmtParserElifFalse :: Test
-testIfStmtParserElifFalse = do
-    let code = unlines [ "if(True)"
-                       , "  i"
-                       , "elif(False)"
-                       , "  j"
-                       ]
-    TestCase $ assertEqual code
-        (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "j")]))) Nothing)
-        (case (parse (ifStatementParser) "" code) of
-             Left  e -> error (show e)
-             Right x -> x)
+    let codeElifTrue = unlines [ "if(True) then do"
+                               , "  i"
+                               , "elif(True) then do"
+                               , "  j"
+                               ]
+    let testElifTrue = TestCase $ assertEqual codeElifTrue
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) Nothing)
+                           (case (parse (ifStatementParser) "" codeElifTrue) of
+                               Left  e -> error (show e)
+                               Right x -> x)
 
-testIfStmtParserElifElse :: Test
-testIfStmtParserElifElse = do
-    let code = unlines [ "if(True)"
-                       , "  i"
-                       , "elif(True)"
-                       , "  j"
-                       , "else"
-                       , "  k"
-                       ]
-    TestCase $ assertEqual code
-        (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) (Just (ElseStatement (Block [Identifier (Name "k")]))))
-        (case (parse (ifStatementParser) "" code) of
-             Left  e -> error (show e)
-             Right x -> x)
+    let codeElifFalse = unlines [ "if(False) then do"
+                                , "  i"
+                                , "elif(False) then do"
+                                , "  j"
+                                ]
+    let testElifFalse = TestCase $ assertEqual codeElifFalse
+                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "j")]))) Nothing)
+                            (case (parse (ifStatementParser) "" codeElifFalse) of
+                                Left  e -> error (show e)
+                                Right x -> x)
 
-testIfStmtParserElse :: Test
-testIfStmtParserElse = do
-    let code = unlines [ "if(True)"
-                       , "  i"
-                       , "else"
-                       , "  k"
-                       ]
-    TestCase $ assertEqual code
-        (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) Nothing (Just (ElseStatement (Block [Identifier (Name "k")]))))
-        (case (parse (ifStatementParser) "" code) of
-             Left  e -> error (show e)
-             Right x -> x)
+    let codeElifElse = unlines [ "if(True) then do"
+                               , "  i"
+                               , "elif(True) then do"
+                               , "  j"
+                               , "else do"
+                               , "  k"
+                               ]
+    let testElifElse = TestCase $ assertEqual codeElifElse
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) (Just (ElseStatement (Block [Identifier (Name "k")]))))
+                           (case (parse (ifStatementParser) "" codeElifElse) of
+                               Left  e -> error (show e)
+                               Right x -> x)
+
+    let codeElse = unlines [ "if(True) then do"
+                           , "  i"
+                           , "else do"
+                           , "  k"
+                           ]
+    let testElse = TestCase $ assertEqual codeElse
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) Nothing (Just (ElseStatement (Block [Identifier (Name "k")]))))
+                       (case (parse (ifStatementParser) "" codeElse) of
+                           Left  e -> error (show e)
+                           Right x -> x)
+
+    TestList [testTrue, testFalse, testElifTrue, testElifFalse, testElifElse, testElse]
+
+testIfStmtParserInline :: Test
+testIfStmtParserInline = do
+    let codeTrue = "if(True) then x"
+    let testTrue = TestCase $ assertEqual codeTrue
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing Nothing)
+                       (case (parse (ifStatementParser) "" codeTrue) of
+                           Left  e -> error (show e)
+                           Right x -> x)
+
+    let codeFalse = "if(False) then x"
+    let testFalse = TestCase $ assertEqual codeFalse
+                        (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing Nothing)
+                        (case (parse (ifStatementParser) "" codeFalse) of
+                           Left  e -> error (show e)
+                           Right x -> x)
+
+
+    let codeElifTrue = unlines [ "if(True) then i"
+                               , "elif(True) then j"
+                               ]
+    let testElifTrue = TestCase $ assertEqual codeElifTrue
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) Nothing)
+                           (case (parse (ifStatementParser) "" codeElifTrue) of
+                               Left  e -> error (show e)
+                               Right x -> x)
+
+    let codeElifFalse = unlines [ "if(False) then i"
+                                , "elif(False) then j"
+                                ]
+    let testElifFalse = TestCase $ assertEqual codeElifFalse
+                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst False) (Block [Identifier (Name "j")]))) Nothing)
+                            (case (parse (ifStatementParser) "" codeElifFalse) of
+                                Left  e -> error (show e)
+                                Right x -> x)
+
+    let codeElifElse = unlines [ "if(True) then i"
+                               , "elif(True) then j"
+                               , "else k"
+                               ]
+    let testElifElse = TestCase $ assertEqual codeElifElse
+                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElifStatement (BoolConst True) (Block [Identifier (Name "j")]))) (Just (ElseStatement (Block [Identifier (Name "k")]))))
+                           (case (parse (ifStatementParser) "" codeElifElse) of
+                               Left  e -> error (show e)
+                               Right x -> x)
+
+    let codeElse = unlines [ "if(True) then i"
+                           , "else then k"
+                           ]
+    let testElse = TestCase $ assertEqual codeElse
+                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) Nothing (Just (ElseStatement (Block [Identifier (Name "k")]))))
+                       (case (parse (ifStatementParser) "" codeElse) of
+                           Left  e -> error (show e)
+                           Right x -> x)
+
+    TestList [testTrue, testFalse, testElifTrue, testElifFalse, testElifElse, testElse]

--- a/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/IfElseStatementParserTest.hs
@@ -73,107 +73,60 @@ testIfStmtParser = do
                            Left  e -> error (show e)
                            Right x -> x)
 
-    TestList [testTrue, testFalse, testElifTrue, testElifFalse, testElifElse, testElse]
-
-testIfStmtParserInline :: Test
-testIfStmtParserInline = do
-    let codeTrue = "if(True) then x"
-    let testTrue = TestCase $ assertEqual codeTrue
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) Nothing)
-                       (case (parse (ifStatementParser) "" codeTrue) of
-                           Left  e -> error (show e)
-                           Right x -> x)
-
-    let codeFalse = "if(False) then x"
-    let testFalse = TestCase $ assertEqual codeFalse
-                        (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
-                        (case (parse (ifStatementParser) "" codeFalse) of
-                           Left  e -> error (show e)
-                           Right x -> x)
-
-    let codeSingleLine = "if(True) then x elif False then y else z"
-    let testSingleLine = TestCase $ assertEqual codeSingleLine
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "x")])) (Just (ElseStatement (Block [Identifier (Name "z")]))))
-                       (case (parse (ifStatementParser) "" codeSingleLine) of
-                           Left  e -> error (show e)
-                           Right x -> x)
-
-    let codeElifTrue = unlines [ "if(True) then i"
-                               , "elif(True) then j"
-                               ]
-    let testElifTrue = TestCase $ assertEqual codeElifTrue
-                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) Nothing)
-                           (case (parse (ifStatementParser) "" codeElifTrue) of
-                               Left  e -> error (show e)
-                               Right x -> x)
-
-    let codeElifFalse = unlines [ "if(False) then i"
-                                , "elif(False) then j"
-                                ]
-    let testElifFalse = TestCase $ assertEqual codeElifFalse
-                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "x")])) Nothing)
-                            (case (parse (ifStatementParser) "" codeElifFalse) of
-                                Left  e -> error (show e)
-                                Right x -> x)
-
-    let codeElifFalseNoParens = unlines [ "if False then i"
-                                        , "elif False then j"
-                                        ]
-    let testElifFalseNoParens = TestCase $ assertEqual codeElifFalseNoParens
-                            (If (IfStatement (BoolConst False) (Block [Identifier (Name "i")])) Nothing)
-                            (case (parse (ifStatementParser) "" codeElifFalseNoParens) of
-                                Left  e -> error (show e)
-                                Right x -> x)
-
-    let codeElifElse = unlines [ "if(True) then i"
-                               , "elif(True) then j"
-                               , "else k"
-                               ]
-    let testElifElse = TestCase $ assertEqual codeElifElse
-                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElseStatement (Block [Identifier (Name "k")]))))
-                           (case (parse (ifStatementParser) "" codeElifElse) of
-                               Left  e -> error (show e)
-                               Right x -> x)
-
-    let codeElse = unlines [ "if(True) then i"
-                           , "else k"
-                           ]
-    let testElse = TestCase $ assertEqual codeElse
-                       (If (IfStatement (BoolConst True) (Block [Identifier (Name "i")])) (Just (ElseStatement (Block [Identifier (Name "k")]))))
-                       (case (parse (ifStatementParser) "" codeElse) of
-                           Left  e -> error (show e)
-                           Right x -> x)
-
-    let codeMultipleInline = unlines [ "if(True) then x; y; z"
-                                     , "elif(True) then i;j;k"
-                                     , "else l;m;n"
-                                     ]
-    let testMultipleInline = TestCase $ assertEqual codeMultipleInline
-                           (If (IfStatement (BoolConst True) (Block [Identifier (Name "x"),Identifier (Name "y"),Identifier (Name "z")])) (Just (ElseStatement (Block [Identifier (Name "l"),Identifier (Name "m"),Identifier (Name "n")]))))
-                           (case (parse (ifStatementParser) "" codeMultipleInline) of
-                               Left  e -> error (show e)
-                               Right x -> x)
-
-    let codeMultipleElifsFinishedWithElse = unlines [ "if(True) then x; y; z"
-                                                    , "elif(True) then i;j;k"
-                                                    , "elif(False) then f;"
-                                                    , "else l;m;n"
+    let codeMultipleElifsFinishedWithElse = unlines [ "if(True) then"
+                                                    , "    x"
+                                                    , "elif(True) then"
+                                                    , "    i"
+                                                    , "elif(False) then"
+                                                    , "    f"
+                                                    , "else"
+                                                    , "    l"
                                                     ]
 
 
-    let testMultipleElifsWithoutElse = unlines [ "if(True) then x; y; z"
-                                               , "elif(True) then i;j;k"
-                                               , "elif(False) then f;"
+    let testMultipleElifsWithoutElse = unlines [ "if(True) then"
+                                               , "    x"
+                                               , "elif(True) then"
+                                               , "    y"
+                                               , "elif(False) then"
+                                               , "    z"
                                                ]
 
 
     let testNestedWithoutElseNoParentheses = unlines [ "if(True) then"
-                                                     , "  if(False) then "
-                                                     , "    k"
-                                                     , "  if True then"
-                                                     , "    j"
-                                                     , "else"
-                                                     , "  m"
+                                                     , "    if(False) then "
+                                                     , "        k"
+                                                     , "    if True then"
+                                                     , "        j"
+                                                     , "    else"
+                                                     , "        m"
                                                      ]
 
-    TestList [testTrue, testFalse, testSingleLine, testElifTrue, testElifFalse, testElifFalseNoParens, testElifElse, testElse, testMultipleInline]
+
+    TestList [testTrue, testFalse, testElifTrue, testElifFalse, testElifElse, testElse]
+
+testIfExpressionParser :: Test
+testIfExpressionParser = do
+
+    let codeIfExpression = "if(True) then i"
+    let testIfExpression = TestCase $ assertEqual codeIfExpression
+                           (If (IfExpression (BoolConst True) (Identifier (Name "i"))) Nothing)
+                           (case (parse (ifExpressionParser) "" codeIfExpression) of
+                               Left  e -> error (show e)
+                               Right x -> x)
+
+    let codeIfElseExpression = "if(True) then i else k"
+    let testIfElseExpression = TestCase $ assertEqual codeIfElseExpression
+                       (If (IfExpression (BoolConst True) (Identifier (Name "i"))) (Just (ElseExpression (Identifier (Name "k")))))
+                       (case (parse (ifExpressionParser) "" codeIfElseExpression) of
+                           Left  e -> error (show e)
+                           Right x -> x)
+
+    let codeIfElseExpressionNoParens = "if False then i else j"
+    let testIfElseExpressionNoParens = TestCase $ assertEqual codeIfElseExpressionNoParens
+                            (If (IfExpression (BoolConst False) (Identifier (Name "i"))) (Just (ElseExpression (Identifier (Name "j")))))
+                            (case (parse (ifExpressionParser) "" codeIfElseExpressionNoParens) of
+                                Left  e -> error (show e)
+                                Right x -> x)
+
+    TestList [testIfExpression, testIfElseExpression, testIfElseExpressionNoParens]

--- a/compiler/test/tests/cobalt/Parser/ParserTests.hs
+++ b/compiler/test/tests/cobalt/Parser/ParserTests.hs
@@ -60,6 +60,7 @@ parserTestList = TestList
     --, testBExprParserTrue
     --, testBExprParserFalse
     --, testBExprParserFail
+    --, testBExprParenthesesConsumerParser
 
     -- RExprParser
     --, testRExprParserGreaterVar

--- a/compiler/test/tests/cobalt/Parser/ParserTests.hs
+++ b/compiler/test/tests/cobalt/Parser/ParserTests.hs
@@ -135,7 +135,7 @@ parserTestList = TestList
     , testIdentifierParserCapital
 
     , testIfStmtParser
-    , testIfStmtParserInline
+    , testIfExpressionParser
 
     --, testImportParserSingle
     --, testImportParserEmptyFail

--- a/compiler/test/tests/cobalt/Parser/ParserTests.hs
+++ b/compiler/test/tests/cobalt/Parser/ParserTests.hs
@@ -134,12 +134,8 @@ parserTestList = TestList
     --, testIdentifierParserStartsDigitFail
     , testIdentifierParserCapital
 
-    , testIfStmtParserBooleanTrue
-    , testIfStmtParserBooleanFalse
-    , testIfStmtParserElifTrue
-    , testIfStmtParserElifFalse
-    , testIfStmtParserElifElse
-    , testIfStmtParserElse
+    , testIfStmtParser
+    , testIfStmtParserInline
 
     --, testImportParserSingle
     --, testImportParserEmptyFail


### PR DESCRIPTION
Resolves #434.
I'm not sure if there is a tidier way of dealing with the choice between inline and do blocks. It's a bit difficult as you have to contain the parsing within the indent block like in `ifDoBlock`. 
