### PR TITLE
Tuple parser now can't parse identifiers inside parentheses.

### DIFF
--- a/compiler/src/cobalt/Parser/Parser.hs
+++ b/compiler/src/cobalt/Parser/Parser.hs
@@ -82,7 +82,7 @@ assignParser = do
 
 expressionParser :: Parser Expr
 expressionParser
-    = tupleParser
+    =   tupleParser
     <|> parens expressionParser'
     <|> newClassInstanceParser
     <|> methodCallParser
@@ -435,6 +435,10 @@ tryBlockParser  = do
 tupleParser :: Parser Expr
 tupleParser =
     try $ do
+        lookAhead $ do
+            symbol "("
+            identifierParser
+            symbol ","
         values <- try $ parens $ sepBy1 identifierParser (symbol ",")
         return $ Tuple (BlockExpr values)
 

--- a/compiler/src/cobalt/Parser/Parser.hs
+++ b/compiler/src/cobalt/Parser/Parser.hs
@@ -82,9 +82,9 @@ assignParser = do
 
 expressionParser :: Parser Expr
 expressionParser
-    =   tupleParser
+    =   newClassInstanceParser
+    <|> tupleParser
     <|> parens expressionParser'
-    <|> newClassInstanceParser
     <|> methodCallParser
     <|> ternaryParser
     <|> IntConst <$> integerParser
@@ -437,9 +437,9 @@ tupleParser =
     try $ do
         lookAhead $ do
             symbol "("
-            identifierParser
+            expressionParser'
             symbol ","
-        values <- try $ parens $ sepBy1 identifierParser (symbol ",")
+        values <- try $ parens $ sepBy1 expressionParser (symbol ",")
         return $ Tuple (BlockExpr values)
 
 typeParameterParser :: Parser [Type]

--- a/compiler/test/tests/cobalt/Parser/TupleParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/TupleParserTest.hs
@@ -12,13 +12,17 @@ testTupleParser = do
     let codeMultiple = "(x, y, z)"
     let testMultiple = testParseSuccess codeMultiple (Tuple (BlockExpr [Identifier (Name "x"),Identifier (Name "y"),Identifier (Name "z")])) expressionParser'
 
+    let codeMultipleExpressions = "((1, \"String\"), y, 100, varName, new ClassName(a, b, c))"
+    let testMultipleExpressions = testParseSuccess codeMultipleExpressions (Tuple (BlockExpr [Tuple (BlockExpr [IntConst 1,StringLiteral "String"]),Identifier (Name "y"),IntConst 100,Identifier (Name "varName"),NewClassInstance (TypeRef (RefLocal (Name "ClassName"))) (BlockExpr [Identifier (Name "a"),Identifier (Name "b"),Identifier (Name "c")]) Nothing])) expressionParser'
+
     let codeTupleEmpty = "()"
     let testTupleEmpty = testParseFailure codeTupleEmpty expressionParser'
 
     let codeSingle = "(a)"
-    let testSingle = testParseFailure codeSingle expressionParser'
+    let testSingle = testParseSuccess codeSingle (Identifier $ Name "a") expressionParser'
 
     TestList [ testMultiple
+             , testMultipleExpressions
              , testTupleEmpty
-             --, testSingle
+             , testSingle
              ]

--- a/compiler/test/tests/cobalt/Parser/TupleParserTest.hs
+++ b/compiler/test/tests/cobalt/Parser/TupleParserTest.hs
@@ -15,8 +15,8 @@ testTupleParser = do
     let codeTupleEmpty = "()"
     let testTupleEmpty = testParseFailure codeTupleEmpty expressionParser'
 
-    -- let codeSingle = "(a)"
-    -- let testSingle = testParseFailure codeSingle expressionParser'
+    let codeSingle = "(a)"
+    let testSingle = testParseFailure codeSingle expressionParser'
 
     TestList [ testMultiple
              , testTupleEmpty


### PR DESCRIPTION
Used lookAhead to ensure a comma is provided next.